### PR TITLE
[BES-1868] Update method missing to use new key_word args for ruby 3.0+

### DIFF
--- a/lib/retriable_proxy.rb
+++ b/lib/retriable_proxy.rb
@@ -26,13 +26,9 @@ module RetriableProxy
     end
   
     # Forwards all methods not defined on the Wrapper to the wrapped object.
-    def method_missing(*a)
-      method_name = a[0]
-      if block_given?
-        __retrying(method_name) { @o.public_send(*a){|*ba| yield(*ba)} }
-      else
-        __retrying(method_name) { @o.public_send(*a) }
-      end
+    def method_missing(*args, **kwargs, &block)
+        method_name = args[0]
+        __retrying(method_name) { @o.public_send(*args, **kwargs, &block) }
     end
   
     private

--- a/retriable_proxy.gemspec
+++ b/retriable_proxy.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<rspec>, ["~> 3.2.0"])
   s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
   s.add_development_dependency(%q<rake>, ["~> 10"])
-  s.add_development_dependency(%q<bundler>, ["~> 1.0"])
+  s.add_development_dependency(%q<bundler>, ["~> 2.0"])
 end


### PR DESCRIPTION
Also:  updated bundler